### PR TITLE
Connect with kafka consumer span

### DIFF
--- a/modules/warehouse/src/main/scala/otel/showcase/warehouse/TextMapPropagatorInterceptor.scala
+++ b/modules/warehouse/src/main/scala/otel/showcase/warehouse/TextMapPropagatorInterceptor.scala
@@ -17,12 +17,15 @@ class TextMapPropagatorInterceptor extends ConsumerInterceptor[Any, Any] {
 
   private var propagator: TextMapPropagator = uninitialized
 
-  override def onConsume(records: ConsumerRecords[Any, Any]): ConsumerRecords[Any, Any] =
-    records.asScala.foreach: record =>
-      Option(Context.current).map: context =>
+  override def onConsume(records: ConsumerRecords[Any, Any]): ConsumerRecords[Any, Any] = {
+    records.asScala.foreach { record =>
+      Option(Context.current).foreach { context =>
         try propagator.inject(context, record.headers, TextMapPropagatorInterceptor.headerSetter)
         catch case _: Throwable => ()
+      }
+    }
     records
+  }
 
   override def onCommit(offsets: util.Map[TopicPartition, OffsetAndMetadata]): Unit = ()
 

--- a/modules/warehouse/src/main/scala/otel/showcase/warehouse/TextMapPropagatorInterceptor.scala
+++ b/modules/warehouse/src/main/scala/otel/showcase/warehouse/TextMapPropagatorInterceptor.scala
@@ -1,0 +1,41 @@
+package otel.showcase.warehouse
+
+import java.nio.charset.StandardCharsets
+import java.util
+
+import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.context.Context
+import io.opentelemetry.context.propagation.{TextMapPropagator, TextMapSetter}
+import org.apache.kafka.clients.consumer.{ConsumerInterceptor, ConsumerRecords, OffsetAndMetadata}
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.header.Headers
+
+import scala.compiletime.uninitialized
+import scala.jdk.CollectionConverters.*
+
+class TextMapPropagatorInterceptor extends ConsumerInterceptor[Any, Any] {
+
+  private var propagator: TextMapPropagator = uninitialized
+
+  override def onConsume(records: ConsumerRecords[Any, Any]): ConsumerRecords[Any, Any] =
+    records.asScala.foreach: record =>
+      Option(Context.current).map: context =>
+        try propagator.inject(context, record.headers, TextMapPropagatorInterceptor.headerSetter)
+        catch case _: Throwable => ()
+    records
+
+  override def onCommit(offsets: util.Map[TopicPartition, OffsetAndMetadata]): Unit = ()
+
+  override def close(): Unit = ()
+
+  override def configure(configs: util.Map[String, ?]): Unit =
+    propagator = GlobalOpenTelemetry.get.getPropagators.getTextMapPropagator
+}
+
+object TextMapPropagatorInterceptor {
+
+  private val headerSetter = new TextMapSetter[Headers] {
+    override def set(carrier: Headers, key: String, value: String): Unit =
+      carrier.remove(key).add(key, value.getBytes(StandardCharsets.UTF_8)): Unit
+  }
+}

--- a/modules/weather-service/src/main/scala/otel/showcase/weather/WeatherService.scala
+++ b/modules/weather-service/src/main/scala/otel/showcase/weather/WeatherService.scala
@@ -1,11 +1,11 @@
 package otel.showcase.weather
 
 import cats.effect.IO
-import fs2.kafka.{Headers, KafkaProducer, ProducerRecord}
+import fs2.kafka.{KafkaProducer, ProducerRecord}
 import io.grpc.Metadata
 import org.slf4j.LoggerFactory
 import org.typelevel.otel4s.Attribute
-import org.typelevel.otel4s.context.propagation.{TextMapGetter, TextMapUpdater}
+import org.typelevel.otel4s.context.propagation.TextMapGetter
 import org.typelevel.otel4s.trace.Tracer
 import otel.showcase.grpc.*
 import otel.showcase.kafka.*
@@ -46,10 +46,7 @@ class WeatherService(
         WeatherRequestMessage(location, origin).toByteArray
       )
 
-      for {
-        headers <- Tracer[IO].propagate(Headers.empty)
-        _       <- producer.produceOne_(record.withHeaders(headers))
-      } yield ()
+      producer.produceOne_(record).void
     }
 
 }
@@ -62,11 +59,6 @@ object WeatherService {
 
     def keys(carrier: Metadata): Iterable[String] =
       carrier.keys().asScala
-  }
-
-  private given TextMapUpdater[Headers] with {
-    def updated(carrier: Headers, key: String, value: String): Headers =
-      carrier.append(key, value)
   }
 
 }


### PR DESCRIPTION
fs2-kafka uses a dedicated process to poll from the kafka server. Because of that the context doesn't hold the correct reference.

Without this the header of kafka records are containing the context of the producer span.
This PR introduces a consumer interceptor, that stores the context of the consumer span in the context.

Sadly the auto instrumentation add 2 consumer spans and the interceptor picks up the first one:
```
producer publish
  |- consumer process
    |- consumer process
    |- doobie INSERT
```

Here are the docs for the interceptor
https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/c257a47e86db1539381b9afe7b9d1517176ef432/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/README.md#using-interceptors



<img width="1039" height="614" alt="Bildschirmfoto 2026-02-16 um 21 50 22" src="https://github.com/user-attachments/assets/8d47a72e-ebf9-4557-a0b5-2427a4106ad2" />
