### PR TITLE
fs2-kafka integration using the interceptor

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,17 @@ lazy val root = project
   .settings(
     name := "otel4s-showcase"
   )
-  .aggregate(gateway, warehouse, `weather-service`, protobuf)
+  .aggregate(gateway, warehouse, `weather-service`, protobuf, `fs2-kafka-otel4s`)
+
+lazy val `fs2-kafka-otel4s` = project
+  .in(file("modules/fs2-kafka-otel4s"))
+  .settings(
+    name := "fs2-kafka-otel4s",
+    libraryDependencies ++= Seq(
+      Libraries.kafka4s,
+      "io.opentelemetry.instrumentation" % "opentelemetry-kafka-clients-2.6" % "2.24.0-alpha"
+    ) ++ Libraries.otel4s
+  )
 
 lazy val protobuf = project
   .in(file("modules/protobuf"))
@@ -98,6 +108,7 @@ lazy val `weather-service` = project
     run / fork  := true,
     javaOptions += "-Dotel.service.name=weather-service",
     javaOptions += "-Dcats.effect.trackFiberContext=true",
+    javaOptions += "-Dotel.instrumentation.kafka.enabled=false",
     javaAgents  += Libraries.openTelemetryAgent,
     libraryDependencies ++= Seq(
       Libraries.catsCore,
@@ -107,7 +118,7 @@ lazy val `weather-service` = project
       Libraries.logback
     ) ++ Libraries.fs2 ++ Libraries.otel4s ++ Libraries.sttp ++ Libraries.http4s ++ Libraries.openTelemetry
   )
-  .dependsOn(protobuf)
+  .dependsOn(protobuf, `fs2-kafka-otel4s`)
 
 // internal request processor
 lazy val warehouse = project
@@ -118,6 +129,7 @@ lazy val warehouse = project
     run / fork  := true,
     javaOptions += "-Dotel.service.name=warehouse",
     javaOptions += "-Dcats.effect.trackFiberContext=true",
+    javaOptions += "-Dotel.instrumentation.kafka.enabled=false",
     javaAgents  += Libraries.openTelemetryAgent,
     libraryDependencies ++= Seq(
       Libraries.catsCore,
@@ -126,4 +138,4 @@ lazy val warehouse = project
       Libraries.logback
     ) ++ Libraries.fs2 ++ Libraries.otel4s ++ Libraries.doobie ++ Libraries.openTelemetry
   )
-  .dependsOn(protobuf)
+  .dependsOn(protobuf, `fs2-kafka-otel4s`)

--- a/modules/fs2-kafka-otel4s/README.md
+++ b/modules/fs2-kafka-otel4s/README.md
@@ -1,0 +1,75 @@
+# fs2-kafka-otel4s
+
+Small helper library to bridge `fs2-kafka`, `otel4s`, and the OpenTelemetry Java Kafka instrumentation.
+
+It provides:
+- Kafka interceptor properties for producer and consumer setup
+- Header propagation support (`Fs2KafkaHeadersTextMapGetter` and `KafkaHeadersTextMapSetter`) for `otel4s`
+- A small helper (`joinOrRoot`) to continue traces from Kafka message headers
+
+## Why this exists
+
+When consuming with `fs2-kafka`, tracing context is typically reconstructed from message headers.  
+The OpenTelemetry Java Kafka consumer instrumentation works at Java client level, while fs2 handlers run later in user code.
+
+This module bridges that gap by:
+- augmenting consumer interceptor configuration with a custom interceptor
+- injecting current context into record headers during consume
+- exposing otel4s-compatible extraction utilities for fs2 records
+
+## Dependency
+
+Add the module to your build:
+
+```scala
+// TODO
+```
+
+## Usage
+
+### Producer configuration
+
+Use OpenTelemetry producer interceptors when building `ProducerSettings`:
+
+```scala
+import fs2.kafka.otel4s.Fs2KafkaOtel4s
+
+ProducerSettings[IO, String, Array[Byte]]
+  .withBootstrapServers("localhost:9092")
+  .withProperties(Fs2KafkaOtel4s.producerInterceptorProperties(otel4s))
+```
+
+### Consumer configuration
+
+Use OpenTelemetry consumer interceptors and include the custom `Fs2KafakConsumerInterceptor`:
+
+```scala
+import fs2.kafka.otel4s.Fs2KafkaOtel4s
+
+ConsumerSettings[IO, String, Array[Byte]]
+  .withBootstrapServers("localhost:9092")
+  .withGroupId("group")
+  .withProperties(Fs2KafkaOtel4s.consumerInterceptorProperties(otel4s))
+```
+
+### Continue trace in record handling
+
+Wrap record processing with `joinOrRoot`:
+
+```scala
+def processRecord(record: ConsumerRecord[String, Array[Byte]])(using Tracer[IO]): IO[Unit] =
+  Fs2KafkaOtel4s.joinOrRoot(record) {
+    // your processing logic
+    IO.unit
+  }
+```
+
+`joinOrRoot` will:
+- join an existing trace when propagation headers are present
+- create a root context when no headers exist
+
+## Notes
+
+- The consumer helper appends `Fs2KafakConsumerInterceptor` to Kafka interceptor properties.
+- Header propagation errors are intentionally ignored in interceptor code to avoid blocking Kafka consumption.
+- In services where this library is used for Kafka tracing, disable conflicting automatic Kafka instrumentation (`-Dotel.instrumentation.kafka.enabled=false`).

--- a/modules/fs2-kafka-otel4s/src/main/scala/fs2/kafka/otel4s/Fs2KafakConsumerInterceptor.scala
+++ b/modules/fs2-kafka-otel4s/src/main/scala/fs2/kafka/otel4s/Fs2KafakConsumerInterceptor.scala
@@ -1,4 +1,4 @@
-package otel.showcase.warehouse
+package fs2.kafka.otel4s
 
 import java.nio.charset.StandardCharsets
 import java.util
@@ -6,36 +6,40 @@ import java.util
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.context.Context
 import io.opentelemetry.context.propagation.{TextMapPropagator, TextMapSetter}
-import org.apache.kafka.clients.consumer.{ConsumerInterceptor, ConsumerRecords, OffsetAndMetadata}
+import io.opentelemetry.instrumentation.kafkaclients.v2_6.internal.OpenTelemetryConsumerInterceptor
+import org.apache.kafka.clients.consumer.{ConsumerRecords, OffsetAndMetadata}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.header.Headers
 
 import scala.compiletime.uninitialized
 import scala.jdk.CollectionConverters.*
 
-class TextMapPropagatorInterceptor extends ConsumerInterceptor[Any, Any] {
+class Fs2KafakConsumerInterceptor extends OpenTelemetryConsumerInterceptor[Any, Any] {
 
   private var propagator: TextMapPropagator = uninitialized
 
   override def onConsume(records: ConsumerRecords[Any, Any]): ConsumerRecords[Any, Any] = {
-    records.asScala.foreach { record =>
+    val instrumentedRecords = super.onConsume(records)
+    instrumentedRecords.asScala.foreach { record =>
       Option(Context.current).foreach { context =>
-        try propagator.inject(context, record.headers, TextMapPropagatorInterceptor.headerSetter)
+        try propagator.inject(context, record.headers, Fs2KafakConsumerInterceptor.headerSetter)
         catch case _: Throwable => ()
       }
     }
-    records
+    instrumentedRecords
   }
 
   override def onCommit(offsets: util.Map[TopicPartition, OffsetAndMetadata]): Unit = ()
 
   override def close(): Unit = ()
 
-  override def configure(configs: util.Map[String, ?]): Unit =
+  override def configure(configs: util.Map[String, ?]): Unit = {
+    super.configure(configs)
     propagator = GlobalOpenTelemetry.get.getPropagators.getTextMapPropagator
+  }
 }
 
-object TextMapPropagatorInterceptor {
+object Fs2KafakConsumerInterceptor {
 
   private val headerSetter = new TextMapSetter[Headers] {
     override def set(carrier: Headers, key: String, value: String): Unit =

--- a/modules/fs2-kafka-otel4s/src/main/scala/fs2/kafka/otel4s/Fs2KafakConsumerInterceptor.scala
+++ b/modules/fs2-kafka-otel4s/src/main/scala/fs2/kafka/otel4s/Fs2KafakConsumerInterceptor.scala
@@ -1,6 +1,5 @@
 package fs2.kafka.otel4s
 
-import java.nio.charset.StandardCharsets
 import java.util
 
 import io.opentelemetry.api.GlobalOpenTelemetry
@@ -14,15 +13,24 @@ import org.apache.kafka.common.header.Headers
 import scala.compiletime.uninitialized
 import scala.jdk.CollectionConverters.*
 
+/**
+  * Extends OpenTelemetry Java consumer interception by mirroring the current context into record headers.
+  *
+  * fs2-kafka processing happens later in user code, where only headers are available for extraction. This interceptor
+  * makes sure every consumed record carries trace propagation data.
+  */
 class Fs2KafakConsumerInterceptor extends OpenTelemetryConsumerInterceptor[Any, Any] {
 
-  private var propagator: TextMapPropagator = uninitialized
+  private val headerSetter: TextMapSetter[Headers] = KafkaHeadersTextMapSetter()
+  private var propagator: TextMapPropagator        = uninitialized
 
   override def onConsume(records: ConsumerRecords[Any, Any]): ConsumerRecords[Any, Any] = {
+    // Keep parent behavior from the Java instrumentation, then enrich headers for fs2 side.
     val instrumentedRecords = super.onConsume(records)
     instrumentedRecords.asScala.foreach { record =>
       Option(Context.current).foreach { context =>
-        try propagator.inject(context, record.headers, Fs2KafakConsumerInterceptor.headerSetter)
+        // Propagation failures must not block Kafka consumption.
+        try propagator.inject(context, record.headers, headerSetter)
         catch case _: Throwable => ()
       }
     }
@@ -33,16 +41,9 @@ class Fs2KafakConsumerInterceptor extends OpenTelemetryConsumerInterceptor[Any, 
 
   override def close(): Unit = ()
 
+  // Reads globally configured propagators (W3C tracecontext/baggage by default).
   override def configure(configs: util.Map[String, ?]): Unit = {
     super.configure(configs)
     propagator = GlobalOpenTelemetry.get.getPropagators.getTextMapPropagator
-  }
-}
-
-object Fs2KafakConsumerInterceptor {
-
-  private val headerSetter = new TextMapSetter[Headers] {
-    override def set(carrier: Headers, key: String, value: String): Unit =
-      carrier.remove(key).add(key, value.getBytes(StandardCharsets.UTF_8)): Unit
   }
 }

--- a/modules/fs2-kafka-otel4s/src/main/scala/fs2/kafka/otel4s/Fs2KafkaHeadersTextMapGetter.scala
+++ b/modules/fs2-kafka-otel4s/src/main/scala/fs2/kafka/otel4s/Fs2KafkaHeadersTextMapGetter.scala
@@ -1,0 +1,12 @@
+package fs2.kafka.otel4s
+
+import fs2.kafka.Headers
+import org.typelevel.otel4s.context.propagation.TextMapGetter
+
+class Fs2KafkaHeadersTextMapGetter extends TextMapGetter[Headers] {
+  override def get(carrier: Headers, key: String): Option[String] =
+    carrier(key).map(_.as[String])
+
+  override def keys(carrier: Headers): Iterable[String] =
+    carrier.toChain.map(_.key).toVector
+}

--- a/modules/fs2-kafka-otel4s/src/main/scala/fs2/kafka/otel4s/Fs2KafkaHeadersTextMapGetter.scala
+++ b/modules/fs2-kafka-otel4s/src/main/scala/fs2/kafka/otel4s/Fs2KafkaHeadersTextMapGetter.scala
@@ -3,10 +3,14 @@ package fs2.kafka.otel4s
 import fs2.kafka.Headers
 import org.typelevel.otel4s.context.propagation.TextMapGetter
 
+/**
+  * Adapter that allows otel4s propagators to read fs2-kafka headers.
+  */
 class Fs2KafkaHeadersTextMapGetter extends TextMapGetter[Headers] {
   override def get(carrier: Headers, key: String): Option[String] =
     carrier(key).map(_.as[String])
 
+  // otel4s uses this to iterate all available propagation keys.
   override def keys(carrier: Headers): Iterable[String] =
     carrier.toChain.map(_.key).toVector
 }

--- a/modules/fs2-kafka-otel4s/src/main/scala/fs2/kafka/otel4s/Fs2KafkaOtel4s.scala
+++ b/modules/fs2-kafka-otel4s/src/main/scala/fs2/kafka/otel4s/Fs2KafkaOtel4s.scala
@@ -1,0 +1,39 @@
+package fs2.kafka.otel4s
+
+import cats.effect.IO
+import fs2.kafka.{ConsumerRecord, Headers}
+import io.opentelemetry.instrumentation.kafkaclients.v2_6.KafkaTelemetry
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.typelevel.otel4s.context.propagation.TextMapGetter
+import org.typelevel.otel4s.oteljava.OtelJava
+import org.typelevel.otel4s.trace.Tracer
+
+import scala.jdk.CollectionConverters.*
+
+object Fs2KafkaOtel4s {
+  def consumerInterceptorProperties(otelJava: OtelJava[IO]): Map[String, String] =
+    KafkaTelemetry
+      .create(otelJava.underlying)
+      .consumerInterceptorConfigProperties()
+      .asScala
+      .concat(
+        Map(
+          ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG -> classOf[Fs2KafakConsumerInterceptor].getName
+        )
+      )
+      .toMap
+      .asInstanceOf[Map[String, String]]
+
+  def producerInterceptorProperties(otelJava: OtelJava[IO]): Map[String, String] =
+    KafkaTelemetry
+      .create(otelJava.underlying)
+      .producerInterceptorConfigProperties()
+      .asScala
+      .toMap
+      .asInstanceOf[Map[String, String]]
+
+  given TextMapGetter[Headers] = Fs2KafkaHeadersTextMapGetter()
+
+  def joinOrRoot[K, V, A](record: ConsumerRecord[K, V])(fa: IO[A])(using Tracer[IO]): IO[A] =
+    Tracer[IO].joinOrRoot(record.headers)(fa)
+}

--- a/modules/fs2-kafka-otel4s/src/main/scala/fs2/kafka/otel4s/Fs2KafkaOtel4s.scala
+++ b/modules/fs2-kafka-otel4s/src/main/scala/fs2/kafka/otel4s/Fs2KafkaOtel4s.scala
@@ -10,7 +10,16 @@ import org.typelevel.otel4s.trace.Tracer
 
 import scala.jdk.CollectionConverters.*
 
+/**
+  * Public helpers to connect fs2-kafka with OpenTelemetry Java agent and otel4s context propagation.
+  */
 object Fs2KafkaOtel4s {
+
+  /**
+    * Producer and consumer use different interception points. On the consumer side we append
+    * [[Fs2KafakConsumerInterceptor]] to the Java agent interceptor chain so every consumed record keeps the current
+    * trace context in headers for downstream fs2 processing.
+    */
   def consumerInterceptorProperties(otelJava: OtelJava[IO]): Map[String, String] =
     KafkaTelemetry
       .create(otelJava.underlying)
@@ -22,8 +31,12 @@ object Fs2KafkaOtel4s {
         )
       )
       .toMap
+      // Java returns a raw map compatible with String keys/values for Kafka config.
       .asInstanceOf[Map[String, String]]
 
+  /**
+    * Builds producer interceptor config provided by the OpenTelemetry Kafka instrumentation.
+    */
   def producerInterceptorProperties(otelJava: OtelJava[IO]): Map[String, String] =
     KafkaTelemetry
       .create(otelJava.underlying)
@@ -32,8 +45,14 @@ object Fs2KafkaOtel4s {
       .toMap
       .asInstanceOf[Map[String, String]]
 
+  /**
+    * Reads trace context from fs2-kafka headers.
+    */
   given TextMapGetter[Headers] = Fs2KafkaHeadersTextMapGetter()
 
+  /**
+    * Continues trace from Kafka headers when present, otherwise starts a new root context.
+    */
   def joinOrRoot[K, V, A](record: ConsumerRecord[K, V])(fa: IO[A])(using Tracer[IO]): IO[A] =
     Tracer[IO].joinOrRoot(record.headers)(fa)
 }

--- a/modules/fs2-kafka-otel4s/src/main/scala/fs2/kafka/otel4s/KafkaHeadersTextMapSetter.scala
+++ b/modules/fs2-kafka-otel4s/src/main/scala/fs2/kafka/otel4s/KafkaHeadersTextMapSetter.scala
@@ -1,0 +1,14 @@
+package fs2.kafka.otel4s
+
+import java.nio.charset.StandardCharsets
+
+import io.opentelemetry.context.propagation.TextMapSetter
+import org.apache.kafka.common.header.Headers
+
+/**
+  * Replaces existing header value to avoid duplicates and keep latest context.
+  */
+class KafkaHeadersTextMapSetter extends TextMapSetter[Headers] {
+  override def set(carrier: Headers, key: String, value: String): Unit =
+    carrier.remove(key).add(key, value.getBytes(StandardCharsets.UTF_8)): Unit
+}

--- a/modules/weather-service/src/main/scala/otel/showcase/weather/Server.scala
+++ b/modules/weather-service/src/main/scala/otel/showcase/weather/Server.scala
@@ -3,6 +3,7 @@ package otel.showcase.weather
 import cats.effect.{IO, IOApp, Resource}
 import fs2.grpc.syntax.all.*
 import fs2.kafka.{KafkaProducer, ProducerSettings}
+import fs2.kafka.otel4s.Fs2KafkaOtel4s
 import io.grpc.{Server, ServerServiceDefinition}
 import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder
 import org.typelevel.otel4s.context.LocalProvider
@@ -30,7 +31,9 @@ object Server extends IOApp.Simple {
       _ <- IORuntimeMetrics.register[IO](runtime.metrics, IORuntimeMetrics.Config.default)
 
       kafkaProducer <- KafkaProducer.resource(
-        ProducerSettings[IO, String, Array[Byte]].withBootstrapServers("localhost:9092")
+        ProducerSettings[IO, String, Array[Byte]]
+          .withBootstrapServers("localhost:9092")
+          .withProperties(Fs2KafkaOtel4s.producerInterceptorProperties(otel4s))
       )
 
       backend <- HttpClientCatsBackend.resource[IO]()


### PR DESCRIPTION
This PR builds upon #5 and uses only the kafka interceptors for the instrumentation. The java agent is no longer required for kafka (in this app is still used for JDBC and grpc)

The `Fs2KafkaOtel4s` object provides convenient method that encapsulate the code to create the consumer or producer interceptor. And a function to set the current context based on the record header.

<img width="1349" height="664" alt="Bildschirmfoto 2026-03-02 um 16 24 01" src="https://github.com/user-attachments/assets/1bb289c0-b409-4683-ac53-c7c167dce647" />


---

> [!NOTE]
> My plan is to add the code in the `fs2-kafka-otel4s` module into either:
>   * fd4s/fs2-kafka as a sub-project
>   * fd4s as a project
>   * fs2-kafka-otel as a project in another org (maybe using just my user like you did for: https://github.com/iRevive/fs2-grpc-otel4s)
>
> I don't know what is the preferred solution